### PR TITLE
Run the long-running D-Bus monitors on EventLoop

### DIFF
--- a/src/bluez/main.cc
+++ b/src/bluez/main.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "bluez_client.h"
 
 int main() {
@@ -20,29 +21,22 @@ int main() {
     // Initialize logging with environment variable configuration
     logging_config::initializeLogging("bluez_client");
 
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     BluezClient client(*connection);
 
     LOG_INFO("BlueZ client running - Press Ctrl+C to exit");
 
-    // Monitor loop with shared connection health timing defaults
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      // Connection was lost
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      // Graceful shutdown via signal
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/geoclue2/main.cc
+++ b/src/geoclue2/main.cc
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <chrono>
-
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "geoclue2_manager.h"
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts so SIGINT/SIGTERM are
+    // blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     const GeoClue2Manager manager(
         *connection, [&](const GeoClue2Location& location) {
@@ -40,7 +43,6 @@ int main() {
     const auto& client = manager.Client();
     if (!client) {
       LOG_ERROR("GeoClue2 did not return a client object; cannot continue");
-      connection->leaveEventLoop();
       return 1;
     }
 
@@ -50,16 +52,9 @@ int main() {
 
     LOG_INFO("Geoclue2 monitor daemon running - Press Ctrl+C to exit");
 
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/login1/main.cc
+++ b/src/login1/main.cc
@@ -12,31 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "login1_manager_client.h"
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     Login1ManagerClient client(*connection);
 
     LOG_INFO("Login1 client running - Press Ctrl+C to exit");
 
-    // Monitor loop with shared connection health timing defaults
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/network1/main.cc
+++ b/src/network1/main.cc
@@ -1,29 +1,25 @@
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "network1_client.h"
-
-#include <chrono>
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     Network1ManagerClient network_manager(*connection);
 
     LOG_INFO("network1 monitor daemon running - Press Ctrl+C to exit");
 
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/networkmanager/main.cc
+++ b/src/networkmanager/main.cc
@@ -12,30 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "networkmanager_client.h"
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     NetworkManagerClient client(*connection);
 
     LOG_INFO("NetworkManager monitor daemon running - Press Ctrl+C to exit");
 
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/resolve1/main.cc
+++ b/src/resolve1/main.cc
@@ -12,31 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "resolve1_manager.h"
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     Resolve1Manager manager(*connection);
 
     LOG_INFO("Resolved client running - Press Ctrl+C to exit");
 
-    // Monitor loop with shared connection health timing defaults
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/systemd1/main.cc
+++ b/src/systemd1/main.cc
@@ -1,29 +1,26 @@
-#include <chrono>
 
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "systemd1_manager_client.h"
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     Systemd1ManagerClient manager(*connection);
 
     LOG_INFO("Systemd1 monitor daemon running - Press Ctrl+C to exit");
 
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/udisks2/main.cc
+++ b/src/udisks2/main.cc
@@ -12,31 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "udisks2_manager.h"
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     UDisks2Manager manager(*connection);
 
     LOG_INFO("UDisks2 client running - Press Ctrl+C to exit");
 
-    // Monitor loop with shared connection health timing defaults
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/udisks2/udisks2_monitor_daemon.cc
+++ b/src/udisks2/udisks2_monitor_daemon.cc
@@ -16,24 +16,22 @@
 
 #include <array>
 #include <bit>
-#include <chrono>
 #include <functional>
 #include <iomanip>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <mutex>
-#include <span>
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <utility>
 #include <vector>
 
 #include "../proxy/org/freedesktop/UDisks2/Block/block_proxy.h"
+#include "../utils/event_loop.h"
 #include "../utils/logging.h"
-#include "../utils/signal_handler.h"
+#include "../utils/signal_source.h"
 
 // Forward declarations
 class RemovableDeviceMonitor;
@@ -505,30 +503,25 @@ int main() {
     LOG_INFO("This daemon monitors for removable device insertions");
     LOG_INFO("Press Ctrl+C to stop...\n");
 
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
+
     // Create the system bus connection
     const auto connection = sdbus::createSystemBusConnection();
-
-    // Enter the event loop asynchronously
-    connection->enterEventLoopAsync();
 
     // Create the monitor with the default callback
     // Users can replace printDeviceInformation with their own lambda
     RemovableDeviceMonitor monitor(*connection, printDeviceInformation);
 
-    // Keep running until interrupted by signal (e.g., Ctrl+C)
-    // The event loop runs in a separate thread handling D-Bus messages
-    // Note: In a production daemon, implement proper signal handling (SIGTERM,
-    // SIGINT) to gracefully shut down and call connection->leaveEventLoop()
-    installSignalHandlers();
-    auto result = monitorLoop(*connection);
-    if (result) {
-      LOG_ERROR("Monitor loop: {}", *result);
-    }
-    connection->leaveEventLoop();
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
   } catch (const std::exception& e) {
     LOG_ERROR("Fatal error: {}", e.what());
     return 1;
   }
-
-  return 0;
 }

--- a/src/upower/main.cc
+++ b/src/upower/main.cc
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "upower_client.h"
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     UPowerClient client(
         *connection,
@@ -28,16 +33,9 @@ int main() {
 
     LOG_INFO("UPower monitor daemon running - Press Ctrl+C to exit");
 
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());

--- a/src/wpa_supplicant/main.cc
+++ b/src/wpa_supplicant/main.cc
@@ -1,29 +1,25 @@
-#include "../utils/signal_handler.h"
+#include "../utils/event_loop.h"
+#include "../utils/signal_source.h"
 #include "wpa_supplicant1_client.h"
-
-#include <chrono>
 
 int main() {
   try {
-    installSignalHandlers();
+    // Single-threaded loop drives the D-Bus connection and signal delivery.
+    // Construct the SignalSource before any thread starts (e.g. spdlog's
+    // flush thread) so SIGINT/SIGTERM are blocked and delivered via the loop.
+    EventLoop loop;
+    SignalSource signals(loop);
+    loop.add(&signals);
 
     const auto connection = sdbus::createSystemBusConnection();
-    connection->enterEventLoopAsync();
 
     WpaSupplicant1Client client(*connection);
 
     LOG_INFO("wpa_supplicant client running - Press Ctrl+C to exit");
 
-    auto result = monitorLoop(*connection);
-
-    if (result) {
-      LOG_ERROR("Exiting due to: {}", *result);
-    } else {
-      LOG_INFO("Shutting down...");
-    }
-
-    connection->leaveEventLoop();
-    return result ? 1 : 0;
+    const int rc = loop.run(*connection);
+    LOG_INFO("Shutting down...");
+    return rc;
 
   } catch (const sdbus::Error& e) {
     LOG_ERROR("D-Bus error: {} - {}", e.getName(), e.getMessage());


### PR DESCRIPTION
Run the long-running D-Bus monitors on EventLoop

Migrate the pure-D-Bus monitor clients from enterEventLoopAsync() + monitorLoop() to the single-threaded EventLoop + SignalSource, matching the BlueZ clients. Each now drives its connection on the main thread and shuts down synchronously via the loop's signalfd instead of a bus-owned thread plus a 100ms poll.

Migrated: bluez, geoclue2, login1, network1, networkmanager, resolve1, systemd1, udisks2, udisks2_monitor_daemon, upower, wpa_supplicant.

Not migrated, by design:
- connman keeps its reconnect-with-exponential-backoff model. Its lifecycle needs to stay responsive to SIGINT/SIGTERM while the system bus is down (before a connection exists), which the signalfd-only model can't do without a bus-less run() variant; the existing installSignalHandlers()/g_running path handles that correctly.
- The one-shot clients that fetch and exit (avahi, flatpak, fwupd, hostname1,
locale1, packagekit, timedate1) and the synchronous examples (realtimekit1, timesync1) are not long-running loops; running them under EventLoop would turn a fetch-and-exit into a daemon.

Verified at runtime: login1 and systemd1 start, drive their D-Bus callbacks on
the loop, and exit cleanly on SIGTERM. Full build green; clang-format --Werror and clang-tidy-19 clean.