### PR TITLE
Adopt sys::expected for the hidraw ioctl chain

### DIFF
--- a/src/bluez/horipad_steam/input_reader.cc
+++ b/src/bluez/horipad_steam/input_reader.cc
@@ -42,9 +42,8 @@ void InputReader::open_and_init() {
 
   // Raw Info
   hidraw_devinfo raw_dev_info{};
-  if (const auto res = ioctl(fd.get(), HIDIOCGRAWINFO, &raw_dev_info);
-      res < 0) {
-    LOG_ERROR("HIDIOCGRAWINFO");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWINFO, &raw_dev_info); !r) {
+    LOG_ERROR("HIDIOCGRAWINFO failed: {}", r.error().message());
     return;
   }
   product_ = raw_dev_info.product;
@@ -54,18 +53,18 @@ void InputReader::open_and_init() {
 
   // Raw Name
   std::array<char, 256> buf{};
-  auto res = ioctl(fd.get(), HIDIOCGRAWNAME(buf.size()), buf.data());
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRAWNAME");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWNAME(buf.size()), buf.data());
+      !r) {
+    LOG_ERROR("HIDIOCGRAWNAME failed: {}", r.error().message());
     return;
   }
   buf.back() = '\0';  // guarantee null-termination
   LOG_INFO("HID Name: {}", buf.data());
 
   // Raw Physical Location
-  res = ioctl(fd.get(), HIDIOCGRAWPHYS(buf.size()), buf.data());
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRAWPHYS");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWPHYS(buf.size()), buf.data());
+      !r) {
+    LOG_ERROR("HIDIOCGRAWPHYS failed: {}", r.error().message());
     return;
   }
   buf.back() = '\0';  // guarantee null-termination
@@ -73,9 +72,8 @@ void InputReader::open_and_init() {
 
   // Report Descriptor Size
   int desc_size = 0;
-  res = ioctl(fd.get(), HIDIOCGRDESCSIZE, &desc_size);
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRDESCSIZE");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRDESCSIZE, &desc_size); !r) {
+    LOG_ERROR("HIDIOCGRDESCSIZE failed: {}", r.error().message());
     return;
   }
   LOG_INFO("Report Descriptor Size: {}", desc_size);
@@ -89,9 +87,8 @@ void InputReader::open_and_init() {
   // Report Descriptor
   hidraw_report_descriptor rpt_desc{};
   rpt_desc.size = desc_size;
-  res = ioctl(fd.get(), HIDIOCGRDESC, &rpt_desc);
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRDESC");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRDESC, &rpt_desc); !r) {
+    LOG_ERROR("HIDIOCGRDESC failed: {}", r.error().message());
     return;
   }
 

--- a/src/bluez/ps5_dual_sense/input_reader.cc
+++ b/src/bluez/ps5_dual_sense/input_reader.cc
@@ -43,9 +43,8 @@ void InputReader::open_and_init() {
 
   // Raw Info
   hidraw_devinfo raw_dev_info{};
-  if (const auto res = ioctl(fd.get(), HIDIOCGRAWINFO, &raw_dev_info);
-      res < 0) {
-    LOG_ERROR("HIDIOCGRAWINFO");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWINFO, &raw_dev_info); !r) {
+    LOG_ERROR("HIDIOCGRAWINFO failed: {}", r.error().message());
     return;
   }
   product_ = raw_dev_info.product;
@@ -55,18 +54,18 @@ void InputReader::open_and_init() {
 
   // Raw Name
   std::array<char, 256> buf{};
-  auto res = ioctl(fd.get(), HIDIOCGRAWNAME(buf.size()), buf.data());
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRAWNAME");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWNAME(buf.size()), buf.data());
+      !r) {
+    LOG_ERROR("HIDIOCGRAWNAME failed: {}", r.error().message());
     return;
   }
   buf.back() = '\0';  // guarantee null-termination
   LOG_INFO("HID Name: {}", buf.data());
 
   // Raw Physical Location
-  res = ioctl(fd.get(), HIDIOCGRAWPHYS(buf.size()), buf.data());
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRAWPHYS");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWPHYS(buf.size()), buf.data());
+      !r) {
+    LOG_ERROR("HIDIOCGRAWPHYS failed: {}", r.error().message());
     return;
   }
   buf.back() = '\0';  // guarantee null-termination
@@ -74,9 +73,8 @@ void InputReader::open_and_init() {
 
   // Report Descriptor Size
   int desc_size = 0;
-  res = ioctl(fd.get(), HIDIOCGRDESCSIZE, &desc_size);
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRDESCSIZE");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRDESCSIZE, &desc_size); !r) {
+    LOG_ERROR("HIDIOCGRDESCSIZE failed: {}", r.error().message());
     return;
   }
   LOG_INFO("Report Descriptor Size: {}", desc_size);
@@ -90,9 +88,8 @@ void InputReader::open_and_init() {
   // Report Descriptor
   hidraw_report_descriptor rpt_desc{};
   rpt_desc.size = desc_size;
-  res = ioctl(fd.get(), HIDIOCGRDESC, &rpt_desc);
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRDESC");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRDESC, &rpt_desc); !r) {
+    LOG_ERROR("HIDIOCGRDESC failed: {}", r.error().message());
     return;
   }
 
@@ -160,10 +157,10 @@ void InputReader::dispatch(const short revents) {
 int InputReader::GetControllerMacAll(const int fd,
                                      ReportFeatureInMacAll& mac_all) {
   mac_all.ReportID = 0x09;
-  if (const auto res =
-          ioctl(fd, HIDIOCGFEATURE(sizeof(ReportFeatureInMacAll)), &mac_all);
-      res < 0) {
-    LOG_ERROR("GetControllerMacAll failed: {}", strerror(errno));
+  if (auto r = sys::ioctl(fd, HIDIOCGFEATURE(sizeof(ReportFeatureInMacAll)),
+                          &mac_all);
+      !r) {
+    LOG_ERROR("GetControllerMacAll failed: {}", r.error().message());
     return 1;
   }
   if (mac_all.ReportID != 0x09 || mac_all.Hard08 != 0x08 ||
@@ -177,10 +174,10 @@ int InputReader::GetControllerMacAll(const int fd,
 int InputReader::GetControllerVersion(const int fd,
                                       ReportFeatureInVersion& version) {
   version.Data.ReportID = 0x20;
-  if (const auto res =
-          ioctl(fd, HIDIOCGFEATURE(sizeof(ReportFeatureInVersion)), &version);
-      res < 0) {
-    LOG_ERROR("GetControllerVersion failed: {}", strerror(errno));
+  if (auto r = sys::ioctl(fd, HIDIOCGFEATURE(sizeof(ReportFeatureInVersion)),
+                          &version);
+      !r) {
+    LOG_ERROR("GetControllerVersion failed: {}", r.error().message());
     return 1;
   }
   if (version.Data.ReportID != 0x20) {
@@ -200,10 +197,10 @@ int InputReader::GetControllerCalibrationData(
 
   ReportFeatureCalibrationData cal_data{};
   cal_data.Data.ReportID = 0x05;
-  if (const auto res = ioctl(
+  if (auto r = sys::ioctl(
           fd, HIDIOCGFEATURE(sizeof(ReportFeatureCalibrationData)), &cal_data);
-      res < 0) {
-    LOG_ERROR("GetControllerCalibrationData failed: {}", strerror(errno));
+      !r) {
+    LOG_ERROR("GetControllerCalibrationData failed: {}", r.error().message());
     return 1;
   }
   if (cal_data.Data.ReportID != 0x05) {

--- a/src/bluez/xbox_controller/input_reader.cc
+++ b/src/bluez/xbox_controller/input_reader.cc
@@ -42,9 +42,8 @@ void InputReader::open_and_init() {
 
   // Raw Info
   hidraw_devinfo raw_dev_info{};
-  if (const auto res = ioctl(fd.get(), HIDIOCGRAWINFO, &raw_dev_info);
-      res < 0) {
-    LOG_ERROR("HIDIOCGRAWINFO");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWINFO, &raw_dev_info); !r) {
+    LOG_ERROR("HIDIOCGRAWINFO failed: {}", r.error().message());
     return;
   }
   product_ = raw_dev_info.product;
@@ -54,18 +53,18 @@ void InputReader::open_and_init() {
 
   // Raw Name
   std::array<char, 256> buf{};
-  auto res = ioctl(fd.get(), HIDIOCGRAWNAME(buf.size()), buf.data());
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRAWNAME");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWNAME(buf.size()), buf.data());
+      !r) {
+    LOG_ERROR("HIDIOCGRAWNAME failed: {}", r.error().message());
     return;
   }
   buf.back() = '\0';  // guarantee null-termination
   LOG_INFO("HID Name: {}", buf.data());
 
   // Raw Physical Location
-  res = ioctl(fd.get(), HIDIOCGRAWPHYS(buf.size()), buf.data());
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRAWPHYS");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRAWPHYS(buf.size()), buf.data());
+      !r) {
+    LOG_ERROR("HIDIOCGRAWPHYS failed: {}", r.error().message());
     return;
   }
   buf.back() = '\0';  // guarantee null-termination
@@ -73,9 +72,8 @@ void InputReader::open_and_init() {
 
   // Report Descriptor Size
   int desc_size = 0;
-  res = ioctl(fd.get(), HIDIOCGRDESCSIZE, &desc_size);
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRDESCSIZE");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRDESCSIZE, &desc_size); !r) {
+    LOG_ERROR("HIDIOCGRDESCSIZE failed: {}", r.error().message());
     return;
   }
   LOG_INFO("Report Descriptor Size: {}", desc_size);
@@ -89,9 +87,8 @@ void InputReader::open_and_init() {
   // Report Descriptor
   hidraw_report_descriptor rpt_desc{};
   rpt_desc.size = desc_size;
-  res = ioctl(fd.get(), HIDIOCGRDESC, &rpt_desc);
-  if (res < 0) {
-    LOG_ERROR("HIDIOCGRDESC");
+  if (auto r = sys::ioctl(fd.get(), HIDIOCGRDESC, &rpt_desc); !r) {
+    LOG_ERROR("HIDIOCGRDESC failed: {}", r.error().message());
     return;
   }
 

--- a/src/utils/sys.h
+++ b/src/utils/sys.h
@@ -21,6 +21,7 @@
 
 #include <fcntl.h>
 #include <sys/eventfd.h>
+#include <sys/ioctl.h>
 #include <sys/signalfd.h>
 #include <sys/stat.h>
 #include <sys/timerfd.h>
@@ -90,6 +91,19 @@ make_signalfd(const int fd, const sigset_t& mask, const int flags) noexcept {
     return std::unexpected(last_error());
   }
   return fd;
+}
+
+/// ioctl() with a single argument, returning the (non-negative) result or the
+/// errno as a std::error_code. `arg` is typically a pointer to the ioctl's
+/// in/out struct.
+template <typename Arg>
+[[nodiscard]] inline std::expected<int, std::error_code>
+ioctl(const int fd, const unsigned long request, Arg arg) noexcept {
+  const int rc = ::ioctl(fd, request, arg);
+  if (rc < 0) {
+    return std::unexpected(last_error());
+  }
+  return rc;
 }
 
 }  // namespace sys

--- a/src/utils/sys_test.cc
+++ b/src/utils/sys_test.cc
@@ -19,6 +19,7 @@
 
 #include <fcntl.h>
 #include <sys/eventfd.h>
+#include <sys/ioctl.h>
 #include <sys/timerfd.h>
 
 #include "logging.h"
@@ -56,6 +57,16 @@ int main() {
         "make_eventfd yields a valid fd");
   check(sys::make_timerfd(CLOCK_MONOTONIC, TFD_CLOEXEC).has_value(),
         "make_timerfd yields a valid fd");
+
+  // ioctl failure: a terminal ioctl on a non-tty fd reports ENOTTY.
+  if (auto efd = sys::make_eventfd(0, EFD_CLOEXEC)) {
+    winsize ws{};
+    auto r = sys::ioctl(efd->get(), TIOCGWINSZ, &ws);
+    check(!r && r.error() == std::errc::inappropriate_io_control_operation,
+          "ioctl on non-tty reports ENOTTY");
+  } else {
+    check(false, "make_eventfd for the ioctl test failed");
+  }
 
   if (failures == 0) {
     LOG_INFO("sys test: PASS");


### PR DESCRIPTION
Adopt sys::expected for the hidraw ioctl chain

Extend the std::expected error-model adoption to ioctl. Add a sys::ioctl
wrapper returning std::expected<int, std::error_code> and convert the hidraw setup chain (HIDIOCGRAWINFO/NAME/PHYS/RDESCSIZE/RDESC) in all three controllers and the ps5 HIDIOCGFEATURE feature reads.

Each failed ioctl now logs the specific errno message (e.g. "HIDIOCGRAWINFO failed: No such device") instead of a bare tag, and the reused `int res` pattern becomes per-call scoped checks. sys_test gains an ioctl case (a terminal ioctl on a non-tty fd -> ENOTTY).